### PR TITLE
Added a new modem: MikroTik R11e-LTE

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Tested devices:
  - HP LT4220
 
  - Dell DW5821e
+ 
+ - MikroTik R11e-LTE
 
 Сompiled old version https://inf.labz.ru/repo/
 

--- a/root/usr/share/modeminfo/scripts/3ginfo.gcom
+++ b/root/usr/share/modeminfo/scripts/3ginfo.gcom
@@ -18,6 +18,11 @@ opengt
  gosub readatcmdnr
  let $v=$s
 
+ let $c="AT+CGMI^m"
+ let $r="+CGMI"
+ gosub readatcmd
+ let $t=$s
+
  if $toupper($mid($v,0,3)) = "HUA" goto huawei
  if $toupper($mid($v,0,3)) = "NOK" goto vodafone
  if $toupper($mid($v,0,3)) = "NOV" goto novatel
@@ -30,6 +35,7 @@ opengt
  if $toupper($mid($v,0,3)) = "QUE" goto quectel
  if $toupper($mid($v,0,3)) = "DEL" goto dell
  if $toupper($mid($k,8,3)) = "XMM" goto intel
+ if $toupper($mid($t,9,3)) = "MIK" goto mikrotik
  goto generic
 
 :simcom
@@ -64,6 +70,23 @@ opengt
  gosub readatcmd
 
  send "AT!GSTATUS?^m"
+ get 1 "" $s
+ print $s
+ goto next
+
+:mikrotik
+ # Activate query mode
+ send "AT+EEMOPT=1^m"
+ # Return information of model
+ let $c="AT+CGMM^m"
+ let $r="+CGMM"
+ gosub readatcmd
+ # Return information of serial number
+ let $c="AT+CGSN^m"
+ let $r="+CGSN"
+ gosub readatcmd
+ # Query GSM/UMTS/LTE information in Engineer
+ send "AT+EEMGINFO?^m"
  get 1 "" $s
  print $s
  goto next

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -1,6 +1,6 @@
 # (c) 2010-2016 Cezary Jackiewicz <cezary@eko.one.pl>
 # (c) 2020-2021 modified by Konstantine Shevlyakov  <shevlakov@132lan.ru>
-# (C) 2021 modified by Vladislav Kadulin  <spanky@yandex.ru>
+# (c) 2021 modified by Vladislav Kadulin  <spanky@yandex.ru>
 
 
 RES="/usr/share/modeminfo"

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -1,5 +1,6 @@
 # (c) 2010-2016 Cezary Jackiewicz <cezary@eko.one.pl>
-# (c) 2020 modified by Konstantine Shevlyakov  <shevlakov@132lan.ru>
+# (c) 2020-2021 modified by Konstantine Shevlyakov  <shevlakov@132lan.ru>
+# (C) 2021 modified by Vladislav Kadulin  <spanky@yandex.ru>
 
 
 RES="/usr/share/modeminfo"
@@ -69,6 +70,8 @@ function modem_family() {
 		FAMILY=DELL
 	elif (echo "$O" | grep -i xmm >/dev/null); then
  		FAMILY=INTEL
+ 	elif (echo "$O" | grep -i mik >/dev/null); then
+ 		FAMILY=MIKROTIK
 	else
 	        FAMILY=GENERIC
 	fi
@@ -128,6 +131,33 @@ function get_cops_zte() {
 		COPS_MCC=${COPS_NUM:0:3}
 		COPS_MNC=${COPS_NUM:3:3}
 	fi
+}
+
+# Get MCC and MNC for MikroTik modem 
+function get_cops_mikrotik() {
+	COPS_TMP=$(echo "$O" | awk -F[\"] '/^\+COPS:/ {print $2}')
+	if [ "x$COPS_TMP" != "x" ]; then
+		COPS=$(awk -F[\;] '/'$COPS_TMP'/ {print $2}' $RES/mccmnc.dat)
+	fi
+}
+
+# Get Registarion data MikroTik
+function get_reg_data_mikrotik() {
+	CREG="CREG:"
+	LAC=$(echo "$O" | awk -F[,] '/\'$CREG'/ {printf "%s", toupper($3)}' | sed 's/[^A-F0-9]//g')
+	LAC_NUM=$(printf %d 0x$LAC)
+	CID=$(echo "$O" | awk -F[','] '/\'CREG:'/ {printf "%s", toupper($4)}' | sed 's/[^A-F0-9]//g')
+	ENBx=$(echo $CID | sed -e 's/..$//')
+	ENBID=$(printf %d 0x$ENBx)
+	if [ "x$CID" != "x" ]; then
+		CID_NUM=$(printf %d 0x$CID)
+		if [ ${#CID} -gt 4 ]; then
+			T=$(echo "$CID" | awk '{print substr($1,length(substr($1,1,length($1)-4))+1)}')
+		else
+			T=$CID
+		fi
+	fi
+	REGST=$(echo "$O"  | awk -F[,] '/^\+CREG:/ {print $2}')
 }
 
 # Get Registarion data
@@ -299,7 +329,7 @@ function sierra_data(){
 	CHIPTEMP=$(echo "$O" | awk '/Temperature:/{print $5}')
 }
 
-# Novatel MOdems
+# Novatel modems
 function novatel_data(){
 	# Novatel
 	TECH=$(echo "$O" | awk -F[,\ ] '/^\$CNTI/ {print $4}' | sed 's|/|,|g')
@@ -520,6 +550,52 @@ function intel_data(){
 	fi
 }
 
+# MikroTik R11e-LTE modem (plat.ver."OpenWrt-18.06.7" router: MikroTik RBM33")
+function mikrotik_data() {	
+	TECH=$(echo "$O" | awk -F[,] '/^\+COPS/ {print $4}')
+	case "$TECH" in
+		0*|1*) MODE="GSM";;   # GSM, GSM Compact
+		2*) MODE="UMTS";;     # UTRAN
+		3*) MODE= "EDGE";;    # GSM w/EGPRS
+		4*|5*) MODE="HSDPA";; # UTRAN w/HSDPA, UTRAN w/HSUPA
+		6*) MODE="HSUPA";;    # UTRAN w/HSDPA and HSUPA
+		7*) MODE="LTE";;      # E-UTRAN
+		8*) MODE="HSPA";;     # UTRAN HSPA+
+		 *) MODE="--";;
+	esac
+	DEVx="$(echo "$O" | awk -F [:,] '/CGMI:|GMM:/{gsub("\"|\r","",$0);print substr($2,2);}')"
+	DEVICE=$(echo $DEVx)
+	IMEI=$(echo echo "$O" | awk -F [:,] '/\+CGSN:/{gsub(" ","", $2); print $2}')
+	EEMGSTATE=$(echo "$O" | awk -F[','] '/\+EEMGINFO/ {print $2}')
+	# LTE Engineering Mode
+	if [ $EEMGSTATE -eq 2 ]; then
+		EEMGINFO=$(echo "$O" | awk -F[':'] '/^\+EEMLTESVC:/ {print $2}')
+		if [ "x$EEMGINFO" != "x" ]; then
+			BW=$(echo $EEMGINFO | awk -F[','] '{print $8}')
+			BWDL=$(echo $EEMGINFO | awk -F[','] '{print $9}')
+			RSRP=$(echo $EEMGINFO | awk -F[','] '{print $11}')
+			RSRQ=$(echo $EEMGINFO | awk -F[','] '{print $12}')
+			SINR=$(echo $EEMGINFO | awk -F[','] '{print $13}')
+			EARFCN=$(echo $EEMGINFO | awk -F[','] '{print $6}')
+			COPS_MCC=$(echo $EEMGINFO | awk -F[','] '{print $1}')
+			COPS_MNC=$(echo $EEMGINFO | awk -F[','] '{print $3}')
+			CSQ_RSSI=$(echo $EEMGINFO | awk -F[','] '{print $18}')
+		fi
+	# UMTS Engineering Mode
+	elif [ $EEMGSTATE -eq 1 ]; then
+		COPS_NUM=$(echo "$O" | awk -F[":"] '/^\+EEMUMTSSV:/ {print $2}')
+		if [ "x$EEMGINFO" != "x" ]; then
+			COPS_MCC=$(echo $EEMGINFO | awk -F[','] '{print $11}')
+			COPS_MNC=$(echo $EEMGINFO | awk -F[','] '{print $12}')
+		fi
+	# GSM Engineering Mode
+	elif [ $EEMGSTATE -eq 0 ]; then
+		COPS_NUM=$(echo "$O" | awk -F[":"] '/^\+EEMGINFOSVC:/ {print $2}')
+		COPS_MCC=$(echo $EEMGINFO | awk -F[','] '{print $1}')
+		COPS_MNC=$(echo $EEMGINFO | awk -F[','] '{print $2}')
+	fi
+}
+
 function generic_data(){
 	TECH=$(echo "$O" | awk -F[,] '/^\+COPS/ {print $4}')
 	case "$TECH" in
@@ -590,6 +666,12 @@ function get_data_in(){
 			get_csq
 			intel_data
 			get_reg_data
+		;;
+		MIKROTIK)
+			get_cops_mikrotik
+			get_csq
+			mikrotik_data
+			get_reg_data_mikrotik
 		;;
 		*)
 			generic_data


### PR DESCRIPTION
Done:
- The modem was added according to the "Luat LTE Module documentation AT Command Interface User Manual Rev1.0".
- Testing was performed on the basis of the router "MikroTik RBM33G" plat.ver."OpenWrt-18.06.7".
- The main code was not changed.
- I also have a MikroTik R11e-4G modem. It is executed on a different chip and does not work with these AT commands. MikroTik does not provide official documentation on AT commands for R11e-LTE and R11e-4G modems.

TODO:
If I can find any documentation on MikroTik R11e-4G, I will add support for this modem. I have a Quectel EM12-G available, if necessary, I am ready to conduct tests.