### PR TITLE
Fixing known bugs

### DIFF
--- a/root/usr/share/modeminfo/scripts/3ginfo.gcom
+++ b/root/usr/share/modeminfo/scripts/3ginfo.gcom
@@ -78,6 +78,10 @@ opengt
  let $c="AT+COPS?^m"
  let $r="+COPS"
  gosub readatcmd
+# Returns received signal quality parameters
+ let $c="AT+CESQ^m"
+ let $r="+CESQ:"
+ gosub readatcmd
 
  let $c="AT+CEREG?^m"
  let $r="+CEREG"

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -619,6 +619,15 @@ function mikrotik_data() {
 	DEVx="$(echo "$O" | awk -F [:,] '/CGMI:|GMM:/{gsub("\"|\r","",$0);print substr($2,2);}')"
 	DEVICE=$(echo $DEVx)
 	IMEI=$(echo echo "$O" | awk -F [:,] '/\+CGSN:/{gsub(" ","", $2); print $2}')
+	CSQ_RSSI=$(echo "$O" | awk -F[':,'] '/^\+CESQ:/ {print $2}')
+	ECIO=$(echo "$O" | awk -F[':,'] '/^\+CESQ:/ {print $5}')
+	# If less than 11 -> error
+	if [ "x$CSQ_RSSI" != "x" ]; then
+		CSQ_RSSI=$(echo $CSQ_RSSI | awk '{if((110 - $1) > 11) print 110 - $1; else print "";}')
+	fi
+	if [ "x$ECIO" != "x" ]; then
+		ECIO=$(echo $ECIO | awk '($1 < 255) {print 25 - $1 * 0.5}')
+	fi
 	# LTE Engineering Mode
 	if [ $EEMGSTATE -eq 2 ]; then
 		EEMGINFO=$(echo "$O" | awk -F[':'] '/^\+EEMLTESVC:/ {print $2}')
@@ -628,10 +637,9 @@ function mikrotik_data() {
 			RSRP=$(echo $EEMGINFO | awk -F[','] '{print $11}')
 			RSRQ=$(echo $EEMGINFO | awk -F[','] '{print $12}')
 			SINR=$(echo $EEMGINFO | awk -F[','] '{print $13}')
-			EARFCN=$(echo $EEMGINFO | awk -F[','] '{print $6}')
 			COPS_MCC=$(echo $EEMGINFO | awk -F[','] '{print $1}')
 			COPS_MNC=$(echo $EEMGINFO | awk -F[','] '{print $3}')
-			CSQ_RSSI=$(echo $EEMGINFO | awk -F[','] '{print $18}')
+			EARFCN=$(echo $EEMGINFO | awk -F[','] '{print $6}')
 		fi
 	# UMTS Engineering Mode
 	elif [ $EEMGSTATE -eq 1 ]; then
@@ -643,8 +651,10 @@ function mikrotik_data() {
 	# GSM Engineering Mode
 	elif [ $EEMGSTATE -eq 0 ]; then
 		COPS_NUM=$(echo "$O" | awk -F[":"] '/^\+EEMGINFOSVC:/ {print $2}')
-		COPS_MCC=$(echo $EEMGINFO | awk -F[','] '{print $1}')
-		COPS_MNC=$(echo $EEMGINFO | awk -F[','] '{print $2}')
+		if [ "x$EEMGINFO" != "x" ]; then
+			COPS_MCC=$(echo $EEMGINFO | awk -F[','] '{print $1}')
+			COPS_MNC=$(echo $EEMGINFO | awk -F[','] '{print $2}')
+		fi
 	fi
 }
 


### PR DESCRIPTION
> KNOWN BUGS for MikroTik modems.
1. Doens't show temperature sensors. Need documentation. (
2. Doens't show RSSI/ECiO on WCDMA/UMTS networks. Need changes.
3. Doens't show RSSI on GSM networks. Need changes.

DONE:
1. There is no information to get the chip temperature. I assume that the vendor has not enabled this feature or it is not documented. If more information appears, the function will be added.
2. Added receiving information about RSSI/ECiO in WCDMA/UMTS mode.
3. Added receiving information about RSSI in GSM mode.
Optimized receiving information from RSSI for all types of networks.