### PR TITLE
Fixed Huawei modem bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Tested devices:
 
  - SimCom SIM7600E-H
 
- - Huawei E3372
+ - Huawei E3372/ME909u-521
 
  - Sierra Wireless EM7455
 

--- a/root/usr/share/modeminfo/scripts/3ginfo.gcom
+++ b/root/usr/share/modeminfo/scripts/3ginfo.gcom
@@ -218,11 +218,14 @@ opengt
  let $c="AT\^FHVER^m"
  let $r="\^FHVER"
  gosub readatcmd
+
+ if $s="\nERROR" goto jumprm
 # remove ^FHVER:" from start of string & " from end of string
  let $s=$mid($s,9,len($s)-10)
  gosub strfindfspace
  let $m=$mid($s,0,i)
 
+:jumprm
  let $c="AT\^SYSINFOEX^m"
  let $r="\^SYSINFOEX"
  gosub readatcmd

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -266,6 +266,11 @@ function huawei_data(){
 		esac
 	fi
 	CHIPTEMP=$(echo "$O" | awk -F[,] '/^\^CHIPTEMP/ {print $4}')
+	# 65535 -> Not supported currently
+	if [ $CHIPTEMP -eq 65535 ]; then
+		# CHIPTEMP for Huawei ME909u-521
+		CHIPTEMP=$(echo "$O" | awk -F[,] '/^\^CHIPTEMP/ {print $6 * 0.1}')
+	fi
 	case $BWDx in
 		1400) BWDL=0 ;;
 		3000) BWDL=1 ;;


### PR DESCRIPTION
Hi! Work has been done to add the "Huawei ME909u-521" modem. 
Fixed: 
 - Added chip temperature, - now the modem correctly shows the temperature in the interface. 
 - Fixed a bug that caused the script to crash due to out-of-range access.