### PR TITLE
modeminfo: Fibocom L860 - new PCI & DISTANCE vars

### DIFF
--- a/root/usr/share/modeminfo/scripts/3ginfo.gcom
+++ b/root/usr/share/modeminfo/scripts/3ginfo.gcom
@@ -182,6 +182,10 @@ opengt
  let $c="AT+MTSM=1^m"
  let $r="+MTSM"
  gosub readatcmd
+
+ send "AT+XMCI=1^m"
+ get 1 "" $s
+ print $s
  goto next
 
 :zte

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -515,6 +515,11 @@ function intel_data(){
 	DEVICE=$(echo $DEVx)
 	if [ $MODE = LTE ]; then
 		EARFCN=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $3}')
+		DISTANCE=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); print $14}')
+		calc() { awk "BEGIN{ printf \"%.2f\n\", $* }"; }
+		DISTANCE=$(calc $(($DISTANCE))*78/1000)
+		PCI=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); print $7}')
+		PCI=$(echo $(($PCI)))
 		LTE_Cx=$(echo "$O" | awk -F [:,] '/\+XLEC:/{print $3}')
 		LTE_CA=$(($LTE_Cx -1))
 		BWDL=$(echo "$O" | awk -F [:,] '/\+XLEC:/{gsub("\r","",$4); print $4}')
@@ -522,13 +527,13 @@ function intel_data(){
 		RSRQ=$(echo "$O" | awk -F [:,] '/\+RSRQ:/{printf "%.0f\n", $4}')
 		BWCx=$(echo "$O" | awk -F [:,] '/\+XLEC/{gsub("\r",""); print $4" "$5" "$6" "$7" "$8}')
 		case $BWDL in
-                        1) NP=15 ;;
-                        2) NP=25 ;;
-                        3) NP=50 ;;
-                        4) NP=75 ;;
-                        5) NP=100 ;;
-                        *) NP=0 ;;
-                esac
+			1) NP=15 ;;
+			2) NP=25 ;;
+			3) NP=50 ;;
+			4) NP=75 ;;
+			5) NP=100 ;;
+			*) NP=0 ;;
+		esac
 		for ca in $BWCx; do
 			case $ca in
 				1) N=3 ;;
@@ -540,32 +545,32 @@ function intel_data(){
 			esac
 			BWCA=$(($BWCA+$N))
 		done
-		case $LTE_CA in                           
-                        1) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6}') ;;          
-                        2) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9}') ;;
-                        3) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9" "$12}') ;;
-                        4) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9" "$12" "$15}') ;;
-                esac
-                for sca in $SCx; do           
-                        if [ $sca -ge 0 ] && [ $sca -le 599 ]; then
-                                SC=1
-                        elif [ $sca -ge 1200 ] && [ $sca -le 1949 ]; then
-                                SC=3                              
-                        elif [ $sca -ge 2750 ] && [ $sca -le 3449 ]; then
-                                SC=7
+		case $LTE_CA in
+			1) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6}') ;;
+			2) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9}') ;;
+			3) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9" "$12}') ;;
+			4) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9" "$12" "$15}') ;;
+		esac
+		for sca in $SCx; do
+			if [ $sca -ge 0 ] && [ $sca -le 599 ]; then
+				SC=1
+			elif [ $sca -ge 1200 ] && [ $sca -le 1949 ]; then
+				SC=3
+			elif [ $sca -ge 2750 ] && [ $sca -le 3449 ]; then
+				SC=7
 			elif [ $sca -ge 3450 ] && [ $sca -le 3799 ]; then
 				SC=8
-                        elif [ $sca -ge 6150 ] && [ $sca -le 6449 ]; then
-                                SC=20
-                        elif [ $sca -ge 9870 ] && [ $sca -le 9919 ]; then
-                                SC=31
-                        elif [ $sca -ge 37750 ] && [ $sca -le 38249 ]; then
-                                SC=38    
-                        elif  [ $sca -ge 38650 ] && [ $sca -le 39649 ]; then
-                                SC=40
-                        fi
-                        SCC=$SCC+$SC
-                done
+			elif [ $sca -ge 6150 ] && [ $sca -le 6449 ]; then
+				SC=20
+			elif [ $sca -ge 9870 ] && [ $sca -le 9919 ]; then
+				SC=31
+			elif [ $sca -ge 37750 ] && [ $sca -le 38249 ]; then
+				SC=38
+			elif [ $sca -ge 38650 ] && [ $sca -le 39649 ]; then
+				SC=40
+			fi
+			SCC=$SCC+$SC
+		done
 		SINx=$(echo "$O" | awk -F [:,] '/\+XCESQ:/{print $9}')
 		if [ $SINx -eq 99 ]; then
 			SINR=""


### PR DESCRIPTION
1. Add calculation of the new variables (quick and dirty):
   PCI - int, Cell ID
   DISTANCE - float (kilometers), distance from the tower

2. Fix indents in Intel block.