### PR TITLE
modeminfo: Intel XMM: change calculation algorithms

### DIFF
--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -111,6 +111,7 @@ function get_hwinfo(){
 
 # get CSQ
 function get_csq(){
+	CSQ=$(echo "$O" | awk -F[,\ ] '/^\+CSQ/ {print $2}')
 	[ "x$CSQ" = "x" ] && CSQ=-1
 	if [ $CSQ -ge 0 -a $CSQ -le 31 ]; then
 		CSQ_PER=$(($CSQ * 100/31))
@@ -122,8 +123,6 @@ function get_csq(){
 	else
 		CSQ_PER="0"
 		CSQ_COL="black"
-	fi
-	# if aviable 
 }
 
 # Get MCC or MNC 
@@ -138,7 +137,6 @@ function get_cops() {
 			COPS="$COPS_MCC $COPS_MNC"
 		fi
 	fi
-	#DISTANCE=$(qmicli -p -d /dev/cdc-wdm0 --nas-get-cell-location-info | awk '/LTE Timing Advance:/{gsub("\047",""); printf "%.2f\n", (299792458*($4*10^-6)/1000)/2}')
 }
 
 # Get MCC or MNC for ZTE modems
@@ -577,33 +575,23 @@ function dell_data(){
 # Intel XMM modems (need changes)
 function intel_data(){
 	generic_data
-	DEVx="$(echo "$O" | awk -F [:,] \
-		'/CGMI:|GMM:/{gsub("\"|\r","",$0); print substr($2,2);}')"
+	DEVx="$(echo "$O" | awk -F [:,] '/CGMI:|GMM:/{gsub("\"|\r","",$0); print substr($2,2);}')"
 	DEVICE=$(echo $DEVx)
 	if [ $MODE = LTE ]; then
 		EARFCN=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $3}')
-		DISTANCE=$(echo "$O" | awk -F [:,] \
-			'/\+XMCI: 4/{gsub(/"/,""); printf "%.2f\n", \
-			($14*78)/1000}')
-		PCI=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); \
-			printf "%d\n", $7}')
-		LAC=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); \
-			printf $5}')
-		LAC_NUM=$(printf %d $LAC)
-		RSRP=$(echo "$O" | awk -F [:,] '/\+RSRP:/{printf \
-			"%.0f\n", $4}')
-		RSRQ=$(echo "$O" | awk -F [:,] '/\+RSRQ:/{printf \
-			"%.0f\n", $4}')
+		DISTANCE=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); printf "%.2f\n", ($14*78)/1000}')
+		PCI=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); printf "%d\n", $7}')
+		# no needed
+		#LAC=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); printf $5}')
+		#LAC_NUM=$(printf %d $LAC)
+		RSRP=$(echo "$O" | awk -F [:,] '/\+RSRP:/{printf "%.0f\n", $4}')
+		RSRQ=$(echo "$O" | awk -F [:,] '/\+RSRQ:/{printf "%.0f\n", $4}')
 		# ! SINR formula needs to be checked !
-		SINR=$(echo "$O" | awk -F [:,] \
-			'/\+XMCI: 4/{gsub(/"/,""); printf "%.0f\n", \
-			$13/2}')
+		SINR=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); printf "%.0f\n", $13/4+5}')
 		LTE_Cx=$(echo "$O" | awk -F [:,] '/\+XLEC:/{print $3}')
 		LTE_CA=$(($LTE_Cx -1))
-		BWDL=$(echo "$O" | awk -F [:,] \
-			'/\+XLEC:/{gsub("\r","",$4); print $4}')
-		BWCx=$(echo "$O" | awk -F [:,] '/\+XLEC/{gsub("\r",""); \
-			print $4" "$5" "$6" "$7" "$8}')
+		BWDL=$(echo "$O" | awk -F [:,] '/\+XLEC:/{gsub("\r","",$4); print $4}')
+		BWCx=$(echo "$O" | awk -F [:,] '/\+XLEC/{gsub("\r",""); print $4" "$5" "$6" "$7" "$8}')
 		case $BWDL in
 			1) NP=15 ;;
 			2) NP=25 ;;
@@ -614,10 +602,8 @@ function intel_data(){
 		esac
 		# RSSI & CSQ look very strange. Therefore we calculate it
 		# through RSSP and number of available resource blocks
-		CSQ_RSSI=$(echo $RSRP $NP | awk '{printf "%.0f\n", \
-			$1+10*log(12*$2)/log(10)}')
-		CSQ=$(echo $CSQ_RSSI | awk '{printf "%.0f\n", \
-			($1+113)/2}')
+		CSQ_RSSI=$(echo $RSRP $NP | awk '{printf "%.0f\n", $1+10*log(12*$2)/log(10)}')
+		CSQ=$(echo $CSQ_RSSI | awk '{printf "%.0f\n",($1+113)/2}')
 		for ca in $BWCx; do
 			case $ca in
 				1) N=3 ;;
@@ -630,32 +616,36 @@ function intel_data(){
 			BWCA=$(($BWCA+$N))
 		done
 		case $LTE_CA in
-			1) SCx=$(echo "$O" | awk -F [:,] \
-				'/\+RSRP:/{print $6}') ;;
-			2) SCx=$(echo "$O" | awk -F [:,] \
-				'/\+RSRP:/{print $6" "$9}') ;;
-			3) SCx=$(echo "$O" | awk -F [:,] \
-				'/\+RSRP:/{print $6" "$9" "$12}') ;;
-			4) SCx=$(echo "$O" | awk -F [:,] \
-				'/\+RSRP:/{print $6" "$9" "$12" "$15}') ;;
+			1) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6}') ;;
+			2) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9}') ;;
+			3) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9" "$12}') ;;
+			4) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9" "$12" "$15}') ;;
 		esac
 		for sca in $SCx; do
 			if [ $sca -ge 0 ] && [ $sca -le 599 ]; then
 				SC=1
+			elif [ $sca -ge 600 ] && [ $sca -le 1199 ]; then
+				SC=2
 			elif [ $sca -ge 1200 ] && [ $sca -le 1949 ]; then
 				SC=3
+			elif [ $sca -ge 1950] && [ $sca -le 2399 ]; then
+				SC=4
+			elif [ $sca -ge 2400] && [ $sca -le 2469 ]; then
+				SC=5
 			elif [ $sca -ge 2750 ] && [ $sca -le 3449 ]; then
 				SC=7
 			elif [ $sca -ge 3450 ] && [ $sca -le 3799 ]; then
 				SC=8
 			elif [ $sca -ge 6150 ] && [ $sca -le 6449 ]; then
 				SC=20
+			elif [ $sca -ge 9210 ] && [ $sca -le 9659 ]; then
+				SC=28
 			elif [ $sca -ge 9870 ] && [ $sca -le 9919 ]; then
 				SC=31
-			elif [ $sca -ge 37750 ] && [ $sca -le 38249 ]; \
-				then SC=38
-			elif [ $sca -ge 38650 ] && [ $sca -le 39649 ]; \
-				then SC=40
+			elif [ $sca -ge 37750 ] && [ $sca -le 38249 ]; hen
+				SC=38
+			elif [ $sca -ge 38650 ] && [ $sca -le 39649 ]; then 
+				SC=40
 			fi
 			SCC=$SCC+$SC
 		done
@@ -665,8 +655,7 @@ function intel_data(){
 		if [ $SINx -eq 99 ]; then
 			SINR=""
 		else
-			SINR=$(echo "$O" | awk -F [:,] \
-				'/\+XCESQ:/{printf "%.0f\n", ($6-50)/2}')
+			SINR=$(echo "$O" | awk -F [:,] '/\+XCESQ:/{printf "%.0f\n", ($6-50)/2}')
 		fi
 	fi
 	CHIPTEMP=$(echo "$O" | awk -F[:,] '/\+MTSM:/{print $2}')

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -109,18 +109,8 @@ function get_hwinfo(){
 	
 }
 
-# get CSQ 
+# get CSQ
 function get_csq(){
-	case $FAMILY in
-		INTEL)
-			case $MODE in
-				# Correct CSQ LTE mode on Intel XMM Fibocom modems 
-				LTE*) CSQ=$(echo $RSRQ $RSRP $NP | awk '{printf "%.0f\n", (113+10*log(((-20-$1)/$2)/$3))/2}') ;;
-				*) CSQ=$(echo "$O" | awk -F[,\ ] '/^\+CSQ/ {print $2}') ;;
-			esac
-		;;
-		*) CSQ=$(echo "$O" | awk -F[,\ ] '/^\+CSQ/ {print $2}') ;;
-	esac
 	[ "x$CSQ" = "x" ] && CSQ=-1
 	if [ $CSQ -ge 0 -a $CSQ -le 31 ]; then
 		CSQ_PER=$(($CSQ * 100/31))
@@ -587,18 +577,33 @@ function dell_data(){
 # Intel XMM modems (need changes)
 function intel_data(){
 	generic_data
-	DEVx="$(echo "$O" | awk -F [:,] '/CGMI:|GMM:/{gsub("\"|\r","",$0);print substr($2,2);}')"
+	DEVx="$(echo "$O" | awk -F [:,] \
+		'/CGMI:|GMM:/{gsub("\"|\r","",$0); print substr($2,2);}')"
 	DEVICE=$(echo $DEVx)
 	if [ $MODE = LTE ]; then
 		EARFCN=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $3}')
-		DISTANCE=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); printf "%.2f\n", ($14*78)/1000}')
-		PCI=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); printf "%d\n", $7}')
+		DISTANCE=$(echo "$O" | awk -F [:,] \
+			'/\+XMCI: 4/{gsub(/"/,""); printf "%.2f\n", \
+			($14*78)/1000}')
+		PCI=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); \
+			printf "%d\n", $7}')
+		LAC=$(echo "$O" | awk -F [:,] '/\+XMCI: 4/{gsub(/"/,""); \
+			printf $5}')
+		LAC_NUM=$(printf %d $LAC)
+		RSRP=$(echo "$O" | awk -F [:,] '/\+RSRP:/{printf \
+			"%.0f\n", $4}')
+		RSRQ=$(echo "$O" | awk -F [:,] '/\+RSRQ:/{printf \
+			"%.0f\n", $4}')
+		# ! SINR formula needs to be checked !
+		SINR=$(echo "$O" | awk -F [:,] \
+			'/\+XMCI: 4/{gsub(/"/,""); printf "%.0f\n", \
+			$13/2}')
 		LTE_Cx=$(echo "$O" | awk -F [:,] '/\+XLEC:/{print $3}')
 		LTE_CA=$(($LTE_Cx -1))
-		BWDL=$(echo "$O" | awk -F [:,] '/\+XLEC:/{gsub("\r","",$4); print $4}')
-		RSRP=$(echo "$O" | awk -F [:,] '/\+RSRP:/{printf "%.0f\n", $4}')
-		RSRQ=$(echo "$O" | awk -F [:,] '/\+RSRQ:/{printf "%.0f\n", $4}')
-		BWCx=$(echo "$O" | awk -F [:,] '/\+XLEC/{gsub("\r",""); print $4" "$5" "$6" "$7" "$8}')
+		BWDL=$(echo "$O" | awk -F [:,] \
+			'/\+XLEC:/{gsub("\r","",$4); print $4}')
+		BWCx=$(echo "$O" | awk -F [:,] '/\+XLEC/{gsub("\r",""); \
+			print $4" "$5" "$6" "$7" "$8}')
 		case $BWDL in
 			1) NP=15 ;;
 			2) NP=25 ;;
@@ -607,6 +612,12 @@ function intel_data(){
 			5) NP=100 ;;
 			*) NP=0 ;;
 		esac
+		# RSSI & CSQ look very strange. Therefore we calculate it
+		# through RSSP and number of available resource blocks
+		CSQ_RSSI=$(echo $RSRP $NP | awk '{printf "%.0f\n", \
+			$1+10*log(12*$2)/log(10)}')
+		CSQ=$(echo $CSQ_RSSI | awk '{printf "%.0f\n", \
+			($1+113)/2}')
 		for ca in $BWCx; do
 			case $ca in
 				1) N=3 ;;
@@ -619,10 +630,14 @@ function intel_data(){
 			BWCA=$(($BWCA+$N))
 		done
 		case $LTE_CA in
-			1) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6}') ;;
-			2) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9}') ;;
-			3) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9" "$12}') ;;
-			4) SCx=$(echo "$O" | awk -F [:,] '/\+RSRP:/{print $6" "$9" "$12" "$15}') ;;
+			1) SCx=$(echo "$O" | awk -F [:,] \
+				'/\+RSRP:/{print $6}') ;;
+			2) SCx=$(echo "$O" | awk -F [:,] \
+				'/\+RSRP:/{print $6" "$9}') ;;
+			3) SCx=$(echo "$O" | awk -F [:,] \
+				'/\+RSRP:/{print $6" "$9" "$12}') ;;
+			4) SCx=$(echo "$O" | awk -F [:,] \
+				'/\+RSRP:/{print $6" "$9" "$12" "$15}') ;;
 		esac
 		for sca in $SCx; do
 			if [ $sca -ge 0 ] && [ $sca -le 599 ]; then
@@ -637,26 +652,21 @@ function intel_data(){
 				SC=20
 			elif [ $sca -ge 9870 ] && [ $sca -le 9919 ]; then
 				SC=31
-			elif [ $sca -ge 37750 ] && [ $sca -le 38249 ]; then
-				SC=38
-			elif [ $sca -ge 38650 ] && [ $sca -le 39649 ]; then
-				SC=40
+			elif [ $sca -ge 37750 ] && [ $sca -le 38249 ]; \
+				then SC=38
+			elif [ $sca -ge 38650 ] && [ $sca -le 39649 ]; \
+				then SC=40
 			fi
 			SCC=$SCC+$SC
 		done
-		SINx=$(echo "$O" | awk -F [:,] '/\+XCESQ:/{print $9}')
-		if [ $SINx -eq 99 ]; then
-			SINR=""
-		else
-			SINR=$(echo "$O" |  awk -F [:,] '/\+XCESQ:/{printf "%.0f\n", ($9/4+5)}')
-		fi
 	else
 		EARFCN=$(echo "$O" | awk -F [:,] '/\+RSCP:/{print $3}')
 		SINx=$(echo "$O" | awk -F [:,] '/\+XCESQ:/{print $6}')
 		if [ $SINx -eq 99 ]; then
 			SINR=""
 		else
-			SINR=$(echo "$O" | awk -F [:,] '/\+XCESQ:/{printf "%.0f\n", ($6-50)/2}')
+			SINR=$(echo "$O" | awk -F [:,] \
+				'/\+XCESQ:/{printf "%.0f\n", ($6-50)/2}')
 		fi
 	fi
 	CHIPTEMP=$(echo "$O" | awk -F[:,] '/\+MTSM:/{print $2}')
@@ -809,9 +819,9 @@ function get_data_in(){
 		;;
 		INTEL)
 			get_cops
+			get_reg_data
 			intel_data
 			get_csq
-			get_reg_data
 		;;
 		MIKROTIK)
 			get_cops_mikrotik

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -643,7 +643,7 @@ function intel_data(){
 				SC=28
 			elif [ $sca -ge 9870 ] && [ $sca -le 9919 ]; then
 				SC=31
-			elif [ $sca -ge 37750 ] && [ $sca -le 38249 ]; hen
+			elif [ $sca -ge 37750 ] && [ $sca -le 38249 ]; then
 				SC=38
 			elif [ $sca -ge 38650 ] && [ $sca -le 39649 ]; then 
 				SC=40

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -123,6 +123,7 @@ function get_csq(){
 	else
 		CSQ_PER="0"
 		CSQ_COL="black"
+	fi
 }
 
 # Get MCC or MNC 

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -1,4 +1,4 @@
-get_csq# (c) 2010-2016 Cezary Jackiewicz <cezary@eko.one.pl>
+# (c) 2010-2016 Cezary Jackiewicz <cezary@eko.one.pl>
 # (c) 2020-2021 modified by Konstantine Shevlyakov  <shevlakov@132lan.ru>
 # (c) 2021 modified by Vladislav Kadulin  <spanky@yandex.ru>
 

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -1,4 +1,4 @@
-# (c) 2010-2016 Cezary Jackiewicz <cezary@eko.one.pl>
+get_csq# (c) 2010-2016 Cezary Jackiewicz <cezary@eko.one.pl>
 # (c) 2020-2021 modified by Konstantine Shevlyakov  <shevlakov@132lan.ru>
 # (c) 2021 modified by Vladislav Kadulin  <spanky@yandex.ru>
 
@@ -809,9 +809,9 @@ function get_data_in(){
 		;;
 		INTEL)
 			get_cops
+			get_csq
 			get_reg_data
 			intel_data
-			get_csq
 		;;
 		MIKROTIK)
 			get_cops_mikrotik


### PR DESCRIPTION
1. Intel XMM: change calculation algorithms for CSQ, CSQ_RSSI, SINR;
2. Changed intel_data, get_csq functions calculation priorities;
3. Fix wrong LAC for LTE;
4. Code style changes in Intel block (long lines were splitted).

Tested of L860-GL
AT+GTPKGVER?
+GTPKGVER: "18600.5001.00.35.01.57_5026.01.001.005"