### PR TITLE
Fix error for Fibocom L850 / L860

### DIFF
--- a/root/usr/share/modeminfo/scripts/3ginfo.gcom
+++ b/root/usr/share/modeminfo/scripts/3ginfo.gcom
@@ -38,6 +38,7 @@ opengt
  if $toupper($mid($v,0,3)) = "ZTE" goto zte
  if $toupper($mid($v,0,3)) = "QUE" goto quectel
  if $toupper($mid($v,0,3)) = "DEL" goto dell
+ if $toupper($mid($k,8,5)) = "XMM75" goto intel
  if $toupper($mid($v,0,3)) = "FIB" goto fibocom
  if $toupper($mid($k,8,3)) = "XMM" goto intel
  if $toupper($mid($t,9,3)) = "MIK" goto mikrotik

--- a/root/usr/share/modeminfo/scripts/3ginfo.gcom
+++ b/root/usr/share/modeminfo/scripts/3ginfo.gcom
@@ -38,9 +38,8 @@ opengt
  if $toupper($mid($v,0,3)) = "ZTE" goto zte
  if $toupper($mid($v,0,3)) = "QUE" goto quectel
  if $toupper($mid($v,0,3)) = "DEL" goto dell
- if $toupper($mid($k,8,5)) = "XMM75" goto intel
+ if $toupper($mid($k,8,5)) = "XMM" goto intel
  if $toupper($mid($v,0,3)) = "FIB" goto fibocom
- if $toupper($mid($k,8,3)) = "XMM" goto intel
  if $toupper($mid($t,9,3)) = "MIK" goto mikrotik
  goto generic
 

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -54,6 +54,8 @@ function modem_family() {
 		FAMILY=QUALCOMM
 	elif (echo ${DEVICE} | grep -i del >/dev/null); then
                 FAMILY=DELL
+        elif (echo "$O" | grep -i "fibocom l8" >/dev/null); then
+                FAMILY=INTEL
 	elif (echo ${DEVICE} | grep -i fib >/dev/null); then
 		FAMILY=FIBOCOM
 	elif (echo "$O" | grep -i xmm >/dev/null); then

--- a/root/usr/share/modeminfo/scripts/modeminfo
+++ b/root/usr/share/modeminfo/scripts/modeminfo
@@ -54,12 +54,10 @@ function modem_family() {
 		FAMILY=QUALCOMM
 	elif (echo ${DEVICE} | grep -i del >/dev/null); then
                 FAMILY=DELL
-        elif (echo "$O" | grep -i "fibocom l8" >/dev/null); then
+        elif (echo "$O" | grep -Ei "l8|xmm" >/dev/null); then
                 FAMILY=INTEL
 	elif (echo ${DEVICE} | grep -i fib >/dev/null); then
 		FAMILY=FIBOCOM
-	elif (echo "$O" | grep -i xmm >/dev/null); then
- 		FAMILY=INTEL
  	elif (echo "$O" | grep -i mik >/dev/null); then
  		FAMILY=MIKROTIK
 	else


### PR DESCRIPTION
There's some issue caused by add support NL668/678, the AT commands seems to be diferent for Fibocom L850 & L860
currently, i'm fixing by call Fibocom L860 as intel family